### PR TITLE
Going back to synchronous interface and supporting older ipykernel

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,9 +57,9 @@ Quick, self contained example:
    display(btn)
 
    # Wait for user to press the button
-   async with ui_events() as poll:
+   with ui_events() as poll:
        while ui_done is False:
-           await poll(10)          # React to UI events (upto 10 at a time)
+           poll(10)          # React to UI events (upto 10 at a time)
            print('.', end='')
            time.sleep(0.1)
    print('done')

--- a/jupyter_ui_poll/_async_thread.py
+++ b/jupyter_ui_poll/_async_thread.py
@@ -1,0 +1,56 @@
+"""
+Tools for working with async tasks
+"""
+import asyncio
+import threading
+
+
+class AsyncThread:
+    @staticmethod
+    def _worker(loop):
+        asyncio.set_event_loop(loop)
+        loop.run_forever()
+        loop.close()
+
+    def __init__(self):
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=AsyncThread._worker, args=(self._loop,))
+        self._thread.start()
+
+    def terminate(self):
+        def _stop(loop):
+            loop.stop()
+
+        if self._loop is None:
+            return
+
+        self.call_soon(_stop, self._loop)
+        self._thread.join()
+        self._loop, self._thread = None, None
+
+    def __del__(self):
+        self.terminate()
+
+    def submit(self, func, *args, **kwargs):
+        """
+        Run async func with args/kwargs in separate thread, returns Future object.
+        """
+        return asyncio.run_coroutine_threadsafe(func(*args, **kwargs), self._loop)
+
+    def wrap(self, func):
+        def sync_func(*args, **kwargs):
+            return self.submit(func, *args, **kwargs).result()
+        return sync_func
+
+    def call_soon(self, func, *args):
+        """
+        Call normal (non-async) function with arguments in the processing thread
+        it's just a wrapper over `loop.call_soon_threadsafe()`
+
+        Returns a handle with `.cancel`, not a full on Future
+        """
+        return self._loop.call_soon_threadsafe(func, *args)
+
+    @property
+    def loop(self):
+        return self._loop

--- a/jupyter_ui_poll/_poll.py
+++ b/jupyter_ui_poll/_poll.py
@@ -1,11 +1,12 @@
 import asyncio
 import sys
 import time
-from contextlib import contextmanager
 
 import zmq
 from IPython import get_ipython
 from tornado.queues import QueueEmpty
+
+from ._async_thread import AsyncThread
 
 
 class KernelWrapper:
@@ -20,6 +21,7 @@ class KernelWrapper:
         self._original_parent = (kernel._parent_ident, kernel.get_parent())
         self._events = []
         self._backup_execute_request = kernel.shell_handlers["execute_request"]
+        self._aproc = None
 
         shell.events.register("post_run_cell", self._post_run_cell_hook)
         kernel.shell_handlers["execute_request"] = self._execute_request_async
@@ -72,6 +74,29 @@ class KernelWrapper:
         KernelWrapper._current = None
         asyncio.ensure_future(self.replay(), loop=self._loop)
 
+    async def _poll_async(self, n=1):
+        for _ in range(n):
+            await self.do_one_iteration()
+
+    async def __aenter__(self):
+        return self._poll_async
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    def __enter__(self):
+        if self._aproc is not None:
+            raise ValueError("Nesting not supported")
+        self._aproc = AsyncThread()
+        return self._aproc.wrap(self._poll_async)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._aproc.terminate()
+        self._aproc = None
+
+    def wrap_iterator(self, its, n: int = 1):
+        return IteratorWrapper(its, self, n=n)
+
     @staticmethod
     def get():
         if KernelWrapper._current is None:
@@ -79,11 +104,41 @@ class KernelWrapper:
         return KernelWrapper._current
 
 
-@contextmanager
+class IteratorWrapper:
+    def __init__(self, its, kernel: KernelWrapper, n: int = 1):
+        self._its = its
+        self._n = n
+        self._kernel = kernel
+
+    def __iter__(self):
+        def _loop(kernel, its, n):
+            with kernel as poll:
+                try:
+                    for x in its:
+                        poll(n)
+                        yield x
+                except GeneratorExit:
+                    pass
+                except Exception as e:
+                    raise e
+
+        return _loop(self._kernel, self._its, self._n)
+
+    def __aiter__(self):
+        async def _loop(kernel, its, n):
+            async with kernel as poll:
+                for x in its:
+                    await poll(n)
+                    yield x
+        return _loop(self._kernel, self._its, self._n)
+
+
 def ui_events():
     """
-    Gives you a async function you can call to process ui events while running a long
+    Gives you a function you can call to process ui events while running a long
     task inside a Jupyter cell.
+
+    Support both async and sync operation.
 
     .. code-block: python
        async with ui_events() as ui_poll:
@@ -91,22 +146,20 @@ def ui_events():
              await ui_poll(10)  # Process upto 10 UI events if any happened
              do_some_more_compute()
 
+        with ui_events() as ui_poll:
+          while some_condition:
+             ui_poll(10)  # Process upto 10 UI events if any happened
+             do_some_more_compute()
 
     - Delay processing `execute_request` IPython kernel events
     - Calls `kernel.do_one_iteration()`
     - Schedule replay of any blocked `execute_request` events upon
       exiting from the context manager
     """
-    kernel = KernelWrapper.get()
-
-    async def poll(n=1):
-        for _ in range(n):
-            await kernel.do_one_iteration()
-
-    yield poll
+    return KernelWrapper.get()
 
 
-async def with_ui_events(its, n=1):
+def with_ui_events(its, n=1):
     """
     Deal with kernel ui events while processing a long sequence
 
@@ -117,18 +170,10 @@ async def with_ui_events(its, n=1):
     - Inject calls to `kernel.do_one_iteration()` in between iterations
     - Schedule replay of any blocked `execute_request` events when data sequence is exhausted
     """
-    with ui_events() as poll:
-        try:
-            for x in its:
-                await poll(n)
-                yield x
-        except GeneratorExit:
-            pass
-        except Exception as e:
-            raise e
+    return KernelWrapper.get().wrap_iterator(its, n)
 
 
-async def run_ui_poll_loop(f, sleep=0.02, n=1):
+def run_ui_poll_loop(f, sleep=0.02, n=1):
     """
     Repeatedly call `f()` until it returns non-None value while also responding to widget events.
 
@@ -153,6 +198,6 @@ async def run_ui_poll_loop(f, sleep=0.02, n=1):
             x = f()
             yield x
 
-    async for x in with_ui_events(as_iterator(f, sleep), n):
+    for x in with_ui_events(as_iterator(f, sleep), n):
         if x is not None:
             return x

--- a/notebooks/ComplexUIExample.ipynb
+++ b/notebooks/ComplexUIExample.ipynb
@@ -23,7 +23,7 @@
     "from ipywidgets import HTML\n",
     "from ui import blocking_ui\n",
     "\n",
-    "color, mode = await blocking_ui(default='beige', timeout=10)"
+    "color, mode = blocking_ui(default='beige', timeout=10)"
    ]
   },
   {
@@ -94,7 +94,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/notebooks/ComplexUIExample.md
+++ b/notebooks/ComplexUIExample.md
@@ -5,8 +5,8 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.2'
-      jupytext_version: 1.5.2
+      format_version: '1.3'
+      jupytext_version: 1.11.3
   kernelspec:
     display_name: Python 3
     language: python
@@ -26,7 +26,7 @@ Run this notebook using `Cell -> Run All` menu option.
 from ipywidgets import HTML
 from ui import blocking_ui
 
-color, mode = await blocking_ui(default='beige', timeout=10)
+color, mode = blocking_ui(default='beige', timeout=10)
 ```
 
 ```python

--- a/notebooks/Examples.ipynb
+++ b/notebooks/Examples.ipynb
@@ -107,7 +107,7 @@
     "with ui_events() as ui_poll:\n",
     "    while int(btn.description) < 10:\n",
     "        print(btn.description, end=\"\")\n",
-    "        await ui_poll(11)  # Process upto 11 ui events per iteration\n",
+    "        ui_poll(11)  # Process upto 11 ui events per iteration\n",
     "        time.sleep(0.1)\n",
     "\n",
     "print(\"... done\")"
@@ -139,7 +139,7 @@
     "print(\"Press this button a few times\")\n",
     "display(btn)\n",
     "\n",
-    "async for i in with_ui_events(range(55), 10):  # Process upto 10 ui events per iteration\n",
+    "for i in with_ui_events(range(55), 10):  # Process upto 10 ui events per iteration\n",
     "    if int(btn.description) >= 5:\n",
     "        print(\"✋\", end=\"\")\n",
     "        break  # Test early exit\n",
@@ -217,7 +217,7 @@
     "print(\"Press button 10 times\")\n",
     "display(btn)\n",
     "\n",
-    "dt = await run_ui_poll_loop(on_poll, 1 / 15)\n",
+    "dt = run_ui_poll_loop(on_poll, 1 / 15)\n",
     "print(\"._.\")  # This should display the text in the output of this cell\n",
     "n_times = \"10 times\"  # To verify that the rest of this cell executes before executing cells below"
    ]
@@ -259,7 +259,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/notebooks/Examples.md
+++ b/notebooks/Examples.md
@@ -5,8 +5,8 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.2'
-      jupytext_version: 1.5.2
+      format_version: '1.3'
+      jupytext_version: 1.11.3
   kernelspec:
     display_name: Python 3
     language: python
@@ -90,7 +90,7 @@ display(btn)
 with ui_events() as ui_poll:
     while int(btn.description) < 10:
         print(btn.description, end="")
-        await ui_poll(11)  # Process upto 11 ui events per iteration
+        ui_poll(11)  # Process upto 11 ui events per iteration
         time.sleep(0.1)
 
 print("... done")
@@ -112,7 +112,7 @@ btn = test_button()
 print("Press this button a few times")
 display(btn)
 
-async for i in with_ui_events(range(55), 10):  # Process upto 10 ui events per iteration
+for i in with_ui_events(range(55), 10):  # Process upto 10 ui events per iteration
     if int(btn.description) >= 5:
         print("✋", end="")
         break  # Test early exit
@@ -176,7 +176,7 @@ btn = test_button()
 print("Press button 10 times")
 display(btn)
 
-dt = await run_ui_poll_loop(on_poll, 1 / 15)
+dt = run_ui_poll_loop(on_poll, 1 / 15)
 print("._.")  # This should display the text in the output of this cell
 n_times = "10 times"  # To verify that the rest of this cell executes before executing cells below
 ```

--- a/notebooks/ui.py
+++ b/notebooks/ui.py
@@ -54,7 +54,7 @@ def make_sample_ui(width="600px"):
     return state
 
 
-async def blocking_ui(default="beige", timeout=10):
+def blocking_ui(default="beige", timeout=10):
     """ Displays a UI then blocks until user makes a choice or timeout happens.
 
         Returns
@@ -105,4 +105,4 @@ async def blocking_ui(default="beige", timeout=10):
 
     # call poll_cbk @ 25 fps,
     # process 4 ui events between calls
-    return await run_ui_poll_loop(poll_cbk, 1 / 25, 4)
+    return run_ui_poll_loop(poll_cbk, 1 / 25, 4)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = jupyter-ui-poll
-version = 0.2.0a0
+version = 0.2.0a1
 
 description = Block jupyter cell execution while interacting with widgets
 long_description = file: README.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ test_suite = tests
 setup_requires =
     setuptools
 install_requires =
-    ipykernel>=6.0.0,<7
+    ipython
     tornado
     pyzmq
 test_requires =


### PR DESCRIPTION
Internally use async loop, but still present synchronous interface as it was in 0.1.3 version. Async interface is also supported and is probably more robust and efficient.

This now creates a separate thread and a new event loop when synchronous interface is used.

Closes #13