### PR TITLE
Support cross-widget messaging

### DIFF
--- a/jupyter_ui_poll/_poll.py
+++ b/jupyter_ui_poll/_poll.py
@@ -54,6 +54,7 @@ class KernelWrapper:
             kernel.shell_handlers["execute_request"] = self._execute_request
 
         shell.events.register("post_run_cell", self._post_run_cell_hook)
+        shell.events.register("post_execute", self._post_run_cell_hook)
 
     def restore(self):
         if self._backup_execute_request is not None:
@@ -116,6 +117,7 @@ class KernelWrapper:
 
     def _post_run_cell_hook(self, *args, **kw):
         self._shell.events.unregister("post_run_cell", self._post_run_cell_hook)
+        self._shell.events.unregister("post_execute", self._post_run_cell_hook)
         self.restore()
         KernelWrapper._current = None
         asyncio.ensure_future(self.replay(), loop=self._loop)


### PR DESCRIPTION
As of 0.2.1, `juypter-ui-poll` only overrides the `post_run_cell` IPython event. This means that `execute_request` is only patched after a cell is run. If you try to link two widgets together, `jupyter-ui-poll` is no longer activated for cross-widget messages because UI actions are generated from the [`post_execute`](https://ipython.readthedocs.io/en/stable/api/generated/IPython.core.events.html#functions) event. Patching `execute_request` for `post_execute` seems to allow cross-widget synchronous messaging to work.